### PR TITLE
Update app and dependencies to GNOME 40

### DIFF
--- a/org.gnome.Weather.json
+++ b/org.gnome.Weather.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Weather",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-weather",
     "finish-args": [
@@ -36,8 +36,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgweather/3.36/libgweather-3.36.1.tar.xz",
-                    "sha256": "de2709f0ee233b20116d5fa9861d406071798c4aa37830ca25f5ef2c0083e450"
+                    "url": "https://download.gnome.org/sources/libgweather/40/libgweather-40.0.tar.xz",
+                    "sha256": "ca4e8f2a4baaa9fc6d75d8856adb57056ef1cd6e55c775ba878ae141b6276ee6"
                 }
             ]
         },
@@ -48,8 +48,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/3.38/gnome-desktop-3.38.0.tar.xz",
-                    "sha256": "089dbbe3c66fe5575659a4a385d5d4bbd99cf637034df317f21cf586b5dd6b90"
+                    "url": "https://download.gnome.org/sources/gnome-desktop/40/gnome-desktop-40.0.tar.xz",
+                    "sha256": "20abfd3f831e4e8092b55839311661dc73b2bf13fc9bef71c4a5a4475da9ee04"
                 }
             ]
         },
@@ -59,8 +59,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-weather/3.36/gnome-weather-3.36.1.tar.xz",
-                    "sha256": "68e6e646159f31c4525c3a5dd308fc0b88dcfc79b61351e9e930dd6efc2ce787"
+                    "url": "https://download.gnome.org/sources/gnome-weather/40/gnome-weather-40.0.tar.xz",
+                    "sha256": "2a35a73ab2408762181d8650b037205c17ef7bcb8dff3cf0b34af1a2de66aeef"
                 }
             ]
         }


### PR DESCRIPTION
`geocode-glib` appears to have no updates, everything else has been updated to 40.0.